### PR TITLE
Change build_depends to configure_depends

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -11,7 +11,7 @@ my $b = AudioFile::Info::Build->new(
         'AudioFile::Info'     => 0,
         'Ogg::Vorbis::Header' => '0.04',
     },
-    build_requires => {
+    configure_requires => {
         'Module::Build' => 0,
         YAML            => 0,
     },


### PR DESCRIPTION
Because they need to be or else YAML doesn't get installed early enough
to successfully build.

This can be tested with a recent CPAN.pm and a perl without YAML installed like:
```
$ perl -MYAML -e 1 
Can't locate YAML.pm in @INC [...]
$ tar xzf AudioFile-Info-Ogg-Vorbis-Header-v1.8.2.tar.gz
$ cd AudioFile-Info-Ogg-Vorbis-Header-v1.8.2
$ cpan -T .
Loading internal logger. Log::Log4perl recommended for better logging
You are visiting the local directory
  '.'
[...]
Can't locate YAML.pm in @INC [...]
[...]
perl Build.PL -- NOT OK
```
With this change, it should install.
```
$ cpan -T .
Loading internal logger. Log::Log4perl recommended for better logging
You are visiting the local directory
  '.'
[...]
  ./Build install  -- OK
```
This should resolve [RT#133896](https://rt.cpan.org/Public/Bug/Display.html?id=133896).